### PR TITLE
Fix typo in VerifyAuthChallenge Lambda

### DIFF
--- a/amplify/backend/function/amplifyIdentityBrokerVerifyAuthChallenge/src/index.js
+++ b/amplify/backend/function/amplifyIdentityBrokerVerifyAuthChallenge/src/index.js
@@ -16,7 +16,7 @@ exports.handler = async (event) => {
 	};
 	var userInfo = await cognitoidentityserviceprovider.getUser(params).promise();
 
-	if (userInfo.Username === event.username) {
+	if (userInfo.Username === event.userName) {
 		event.response.answerCorrect = true;
 	} else {
 		// Someone tried to get a token of someone else


### PR DESCRIPTION
*Issue #, if available:*
#326 Token Swap does not work

*Description of changes:*
1. Fix typo
  a. username => [userName](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-event-parameter-shared)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
