### PR TITLE
Feature/userinfo

### DIFF
--- a/Documentation/ClientDeveloperDocumentation.md
+++ b/Documentation/ClientDeveloperDocumentation.md
@@ -329,5 +329,4 @@ You may already have an existing application that is a OIDC standard client.
 
 If this is the case you can integrate your application with the broker but keep in mind that:
 * not all the flows and endpoint are implemented
-* the broker is not 100% standard see the [differences with the OIDC standard](./UserDocumentation.md#differences-with-the-oidc-standard) section.
 

--- a/Documentation/UserDocumentation.md
+++ b/Documentation/UserDocumentation.md
@@ -4,7 +4,6 @@ __[User Documentation](UserDocumentation.md)__ / [Client Developer Documentation
 
 - [Presentation](#presentation)
 	- [Choose your flow](#choose-your-flow)
-	- [Difference with the OIDC standard](#difference-with-the-oidc-standard)
 - [Deployment](#deployment)
 	- [Architecture](#architecture)
 	- [Deployment Instructions](#deployment-instructions)
@@ -14,7 +13,7 @@ __[User Documentation](UserDocumentation.md)__ / [Client Developer Documentation
 	- [Step 3: Configure domain (mandatory)](#step-3-configure-domain-mandatory)
 	- [Step 4: E2E Test (Optional)](#step-4-e2e-test-optional)
 - [Register a client](#register-a-client)
-- [CSS & UI components customization instruction](#css--ui-components-customization-instruction)
+- [CSS \& UI components customization instruction](#css--ui-components-customization-instruction)
 - [Identity Providers](#identity-providers)
 	- [OIDC Provider (oauth2)](#oidc-provider-oauth2)
 	- [SAML Provider](#saml-provider)
@@ -101,12 +100,6 @@ Expand the section below to see the detailed flows:
 </details>
 
 See [Client Developer Documentation](./ClientDeveloperDocumentation.md) to see how to implement a client using these flows.
-
-### Difference with the OIDC standard
-
-The AWS Amplify identity broker follows the [OpenID Connect 1.0 standard](https://openid.net/specs/openid-connect-core-1_0.html) with one exception:
-
-__/oauth2/userinfo__: The Oauth2 standard [stipulate](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) that the UserInfo endpoint MUST accept Access Tokens as OAuth 2.0 Bearer Token Usage. The broker do not use that but instead is expecting the token to be provided inside a HTTP header named __access_token__. If this is a bloker for you, you can use the [UserInfo endpoint that Amazon Cognito expose](https://docs.aws.amazon.com/cognito/latest/developerguide/userinfo-endpoint.html) directly.
 
 ## Deployment
 

--- a/amplify/backend/function/amplifyIdentityBrokerUserInfo/src/index.js
+++ b/amplify/backend/function/amplifyIdentityBrokerUserInfo/src/index.js
@@ -11,25 +11,34 @@ const AWS = require('aws-sdk');
 var cognitoidentityserviceprovider = new AWS.CognitoIdentityServiceProvider();
 
 exports.handler = async (event) => {
-	// Reference here https://docs.aws.amazon.com/cognito/latest/developerguide/userinfo-endpoint.html
-	// Getting access token from access_token header which is not standard. 
-	// Should get from Authorization header but that is not passed in the event through lambda proxy integration
-	var accessToken = event.headers.access_token;
-	if (accessToken === undefined) {
+	// Reference: https://docs.aws.amazon.com/cognito/latest/developerguide/userinfo-endpoint.html
+	// Getting access token from Authorization header and proxy to cognito
+
+	var authHeader = event.headers.Authorization;
+	if (authHeader === undefined
+		|| authHeader.split(" ").length !== 2
+		|| authHeader.split(" ")[0] !== "Bearer"
+	) {
 		return {
 			statusCode: 400,
 			body: JSON.stringify("Missing access token"),
 		};
 	}
 
+	var accessToken = authHeader.split(" ")[1];
+
 	var params = {
 		AccessToken: accessToken
 	};
 	var userInfo = await cognitoidentityserviceprovider.getUser(params).promise();
 
-	// Need to change return format to match reference
+	var res = userInfo.UserAttributes.reduce((a, b) => {
+		a[b["Name"]] = b["Value"];
+		return a;
+	}, {});
+
 	return {
 		statusCode: 200,
-		body: JSON.stringify(userInfo.UserAttributes),
+		body: JSON.stringify(res),
 	};
 };

--- a/amplify/backend/hosting/S3AndCloudFront/template.json
+++ b/amplify/backend/hosting/S3AndCloudFront/template.json
@@ -202,6 +202,9 @@
               ],
               "TargetOriginId": "amplifyIdentityBrokerApiGateway",
               "ForwardedValues": {
+                "Headers": [
+                  "Authorization"
+                ],
                 "QueryString": "true",
                 "Cookies": {
                   "Forward": "all"

--- a/cypress/integration/authenticator_spec.js
+++ b/cypress/integration/authenticator_spec.js
@@ -1,4 +1,7 @@
+import awsconfig from "../../src/aws-exports";
+
 describe('Authenticator:', function () {
+	let access_token
 	beforeEach(function () {
 		cy.visit('/');
 	});
@@ -9,8 +12,22 @@ describe('Authenticator:', function () {
 			cy.get(selectors.signInSignInButton).contains('Sign In').click();
 			cy.wait(3000)
 			cy.get(selectors.root).contains('Amplify Identity Broker');
+			cy.getCookie('access_token').should('exist')
+				.then((c) => {
+					access_token = c.value
+				});
 		});
 	});
+	describe('User Info:', () => {
+		it('allows a user to fetch user info', () => {
+			cy.request({ url: awsconfig.oauth.redirectSignIn + '/oauth2/userInfo', headers: { "Authorization": "Bearer " + access_token } }).then(
+				(response) => {
+					console.log(response)
+					expect(response.body).to.have.property('email_verified', 'true') // true
+				}
+			)
+		})
+	})
 });
 export const selectors = {
 	emailInput: '[data-test="sign-in-email-input"]',


### PR DESCRIPTION
*Issue #, if available:*
#27 

*Description of changes:*
Changed `/oauth2/userinfo` to align with [Oauth2 standard](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)

- Changed CloudFront setting to pass Authorization header ([Amplify Hosting by default pass Authorization header](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html))
- Changed endpoint to get access token from Authorizaiton header instaed of access_token header
- Changed response structure
- Updated documentation
- Added integration test of the change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
